### PR TITLE
set font size for li's

### DIFF
--- a/assets/stylesheets/xpressio.css
+++ b/assets/stylesheets/xpressio.css
@@ -562,6 +562,7 @@ ol > li {
 }
 li {
   padding: 10px 0px;
+  font-size: 0.85em;
 }
 ul {
   margin: 0 0 25px 0;


### PR DESCRIPTION
Just noticed the list items weren't given the same font size as p's. 

Thanks for a great blog theme!
